### PR TITLE
Не верный путь до бинарника git add godep-9999.ebuild! dobin: /var/tm…

### DIFF
--- a/app-misc/godep/godep-9999.ebuild
+++ b/app-misc/godep/godep-9999.ebuild
@@ -36,7 +36,7 @@ src_compile() {
 src_install() {
 #	go install -v -x -work ${GO_PN} || die
 
-dobin ${S}/bin/godep
+dobin ${S}/godep
 #insinto /usr/lib/go/
 #doins -r "${S}/pkg"
 #insinto /usr/lib/go/src/pkg


### PR DESCRIPTION
…p/portage/app-misc/godep-9999/work/godep-9999/bin/godep does not exist