### PR TITLE
fix version regexp

### DIFF
--- a/net-p2p/syncthing/syncthing-9999.ebuild
+++ b/net-p2p/syncthing/syncthing-9999.ebuild
@@ -34,7 +34,7 @@ S="${EGIT_CHECKOUT_DIR}"
 
 src_compile() {
 	# XXX: All the stuff below needs for "-version" command to show actual info
-	local version="$(git describe --always | sed 's/\([v\.0-9]*\)\(-\(beta\|alpha\)[0-9]*\)\?-/\1\2+/')";
+	local version="$(git describe --always | sed 's/\([v\.0-9]*\)\(-\(beta\|alpha\)\.[0-9]*\)\?-/\1\2+/')";
 	local date="$(git show -s --format=%ct)";
 	local user="$(whoami)"
 	local host="$(hostname)"; host="${host%%.*}";


### PR DESCRIPTION
Со старым регэкспом выдает 
>FATAL: Invalid version string "v0.13.0+beta.0-47-g56db1d3";
>        does not match regexp ^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-dirty)?$
