### PR TITLE
fix fresh install of yandex-browser-beta

### DIFF
--- a/www-client/yandex-browser-beta/yandex-browser-beta-16.9.1.466_p1.ebuild
+++ b/www-client/yandex-browser-beta/yandex-browser-beta-16.9.1.466_p1.ebuild
@@ -87,7 +87,7 @@ src_install() {
 	make_wrapper "${PN}" "./${PN}" "/${YANDEX_HOME}" "/usr/$(get_libdir)/${PN}/lib"
 	dosym /usr/$(get_libdir)/libudev.so /usr/$(get_libdir)/${PN}/lib/libudev.so.0
 
-	for icon in "/${YANDEX_HOME}/product_logo_"*.png; do
+	for icon in "${D}/${YANDEX_HOME}/product_logo_"*.png; do
 		size="${icon##*/product_logo_}"
 		size=${size%.png}
 		dodir "/usr/share/icons/hicolor/${size}x${size}/apps"


### PR DESCRIPTION
Fresh install of yandex-browser-beta doesn't work because of wrong path to icons.