### PR TITLE
Improve mergerfs ebuild

### DIFF
--- a/sys-fs/mergerfs/mergerfs-9999.ebuild
+++ b/sys-fs/mergerfs/mergerfs-9999.ebuild
@@ -3,36 +3,40 @@
 
 EAPI=6
 
-inherit git-r3
-
 DESCRIPTION="Another (FUSE based) union filesystem"
 HOMEPAGE="https://github.com/trapexit/mergerfs"
 
+if [[ ${PV} == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/trapexit/mergerfs"
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/trapexit/mergerfs/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64 ~x86"
+fi
+
+
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS=""
 IUSE=""
 #IUSE="man-regen"
-EGIT_REPO_URI="https://github.com/trapexit/mergerfs"
 
 RDEPEND="
 	sys-apps/attr:=
 	>=sys-apps/util-linux-2.18
 	sys-devel/gettext:=
 "
-#	sys-fs/fuse[static-libs]:=
-
-#TODO:
-#	1) unbundle fuse
-#	2) optional man regen
 
 DEPEND="
 	${RDEPEND}
 "
+
+#TODO: optional man regen
 #	man-regen? ( app-text/pandoc )
 
 src_install() {
 	dobin mergerfs
+	dosym mergerfs /usr/bin/mount.mergerfs
 	dodoc README.md
 	doman man/mergerfs.1
 }


### PR DESCRIPTION
+ Support git and non-git source in a single ebuild (just rename to e.g. mergerfs-2.24.2.ebuild)
+ Remove libfuse todo, since the mergerfs developers tend to patch their bundled libfuse
+ Create mount.mergerfs symlink (just like make install does)