### PR TITLE
telegram: bump

### DIFF
--- a/net-im/telegram-desktop/files/cmake/Telegram.cmake
+++ b/net-im/telegram-desktop/files/cmake/Telegram.cmake
@@ -53,8 +53,11 @@ list(APPEND THIRD_PARTY_INCLUDE_DIRS
 	${THIRD_PARTY_DIR}/emoji_suggestions
 	${THIRD_PARTY_DIR}/libtgvoip
 	${THIRD_PARTY_DIR}/variant/include
-	${THIRD_PARTY_DIR}/qtlottie/src/bodymovin
-	${THIRD_PARTY_DIR}/qtlottie/src/imports
+	${THIRD_PARTY_DIR}/rlottie/inc
+	${THIRD_PARTY_DIR}/rlottie/src/lottie
+	${THIRD_PARTY_DIR}/rlottie/src/vector
+	${THIRD_PARTY_DIR}/rlottie/src/vector/pixman
+	${THIRD_PARTY_DIR}/rlottie/src/vector/freetype
 )
 
 add_subdirectory(${THIRD_PARTY_DIR}/crl)
@@ -91,6 +94,7 @@ file(GLOB FLAT_SOURCE_FILES
 	SourceFiles/core/*.cpp
 	SourceFiles/data/*.cpp
 	SourceFiles/dialogs/*.cpp
+	SourceFiles/ffmpeg/*.cpp
 	SourceFiles/history/*.cpp
 	SourceFiles/inline_bots/*.cpp
 	SourceFiles/intro/*.cpp
@@ -107,8 +111,10 @@ file(GLOB FLAT_SOURCE_FILES
 	SourceFiles/support/*cpp
 	SourceFiles/lottie/*.cpp
 	${THIRD_PARTY_DIR}/emoji_suggestions/*.cpp
-	${THIRD_PARTY_DIR}/qtlottie/src/bodymovin/*.cpp
-	${THIRD_PARTY_DIR}/qtlottie/src/imports/rasterrenderer/*.cpp
+	${THIRD_PARTY_DIR}/rlottie/src/lottie/*.cpp
+	${THIRD_PARTY_DIR}/rlottie/src/vector/*.cpp
+	${THIRD_PARTY_DIR}/rlottie/src/vector/freetype/*.cpp
+	${THIRD_PARTY_DIR}/rlottie/src/vector/pixman/*.cpp
 )
 
 file(GLOB FLAT_EXTRA_FILES
@@ -125,6 +131,8 @@ file(GLOB FLAT_EXTRA_FILES
 	# As of 1.3.15 Passport still doesn't work. TODO: remove that, when it'll be fixed
 	SourceFiles/passport/passport_edit_identity_box.cpp
 	SourceFiles/passport/passport_form_row.cpp
+	
+	${THIRD_PARTY_DIR}/rlottie/src/vector/pixman/pixman-arm-neon-asm.S
 )
 
 file(GLOB_RECURSE SUBDIRS_SOURCE_FILES
@@ -176,6 +184,7 @@ set(TELEGRAM_INCLUDE_DIRS
 set(TELEGRAM_LINK_LIBRARIES
 	xxhash
 	crl
+	lz4
 	tgvoip
 	OpenSSL::Crypto
 	OpenSSL::SSL

--- a/net-im/telegram-desktop/files/patches/1.7.14/0002_use-private-Qt-color-API-only-in-official-build.patch
+++ b/net-im/telegram-desktop/files/patches/1.7.14/0002_use-private-Qt-color-API-only-in-official-build.patch
@@ -1,0 +1,150 @@
+From 0710dde4d5526454318b2748331e887c01ecfdce Mon Sep 17 00:00:00 2001
+From: John Preston <johnprestonmail@gmail.com>
+Date: Tue, 9 Jul 2019 13:43:57 +0200
+Subject: Use private Qt color API only in official build.
+
+Fixes #6219.
+
+diff --git a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
+index 5d0e50926..3775f7503 100644
+--- a/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
++++ b/Telegram/SourceFiles/ffmpeg/ffmpeg_utility.cpp
+@@ -11,7 +11,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "logs.h"
+
+ #include <QImage>
++
++#ifdef TDESKTOP_OFFICIAL_TARGET
+ #include <private/qdrawhelper_p.h>
++#endif // TDESKTOP_OFFICIAL_TARGET
+
+ extern "C" {
+ #include <libavutil/opt.h>
+@@ -44,6 +47,58 @@ void AlignedImageBufferCleanupHandler(void* data) {
+ 		&& !(image.bytesPerLine() % kAlignImageBy);
+ }
+
++void UnPremultiplyLine(uchar *dst, const uchar *src, int intsCount) {
++#ifdef TDESKTOP_OFFICIAL_TARGET
++	const auto layout = &qPixelLayouts[QImage::Format_ARGB32];
++	const auto convert = layout->convertFromARGB32PM;
++#else // TDESKTOP_OFFICIAL_TARGET
++	const auto layout = nullptr;
++	const auto convert = [](
++			uint *dst,
++			const uint *src,
++			int count,
++			std::nullptr_t,
++			std::nullptr_t) {
++		for (auto i = 0; i != count; ++i) {
++			dst[i] = qUnpremultiply(src[i]);
++		}
++	};
++#endif // TDESKTOP_OFFICIAL_TARGET
++
++	convert(
++		reinterpret_cast<uint*>(dst),
++		reinterpret_cast<const uint*>(src),
++		intsCount,
++		layout,
++		nullptr);
++}
++
++void PremultiplyLine(uchar *dst, const uchar *src, int intsCount) {
++#ifdef TDESKTOP_OFFICIAL_TARGET
++	const auto layout = &qPixelLayouts[QImage::Format_ARGB32];
++	const auto convert = layout->convertToARGB32PM;
++#else // TDESKTOP_OFFICIAL_TARGET
++	const auto layout = nullptr;
++	const auto convert = [](
++			uint *dst,
++			const uint *src,
++			int count,
++			std::nullptr_t,
++			std::nullptr_t) {
++		for (auto i = 0; i != count; ++i) {
++			dst[i] = qPremultiply(src[i]);
++		}
++	};
++#endif // TDESKTOP_OFFICIAL_TARGET
++
++	convert(
++		reinterpret_cast<uint*>(dst),
++		reinterpret_cast<const uint*>(src),
++		intsCount,
++		layout,
++		nullptr);
++}
++
+ } // namespace
+
+ IOPointer MakeIOPointer(
+@@ -360,58 +415,35 @@ void UnPremultiply(QImage &to, const QImage &from) {
+ 	if (!GoodStorageForFrame(to, from.size())) {
+ 		to = CreateFrameStorage(from.size());
+ 	}
+-
+-	const auto layout = &qPixelLayouts[QImage::Format_ARGB32];
+-	const auto convert = layout->convertFromARGB32PM;
+ 	const auto fromPerLine = from.bytesPerLine();
+ 	const auto toPerLine = to.bytesPerLine();
+ 	const auto width = from.width();
++	const auto height = from.height();
++	auto fromBytes = from.bits();
++	auto toBytes = to.bits();
+ 	if (fromPerLine != width * 4 || toPerLine != width * 4) {
+-		auto fromBytes = from.bits();
+-		auto toBytes = to.bits();
+-		for (auto i = 0; i != to.height(); ++i) {
+-			convert(
+-				reinterpret_cast<uint*>(toBytes),
+-				reinterpret_cast<const uint*>(fromBytes),
+-				width,
+-				layout,
+-				nullptr);
++		for (auto i = 0; i != height; ++i) {
++			UnPremultiplyLine(toBytes, fromBytes, width);
+ 			fromBytes += fromPerLine;
+ 			toBytes += toPerLine;
+ 		}
+ 	} else {
+-		convert(
+-			reinterpret_cast<uint*>(to.bits()),
+-			reinterpret_cast<const uint*>(from.bits()),
+-			from.width() * from.height(),
+-			layout,
+-			nullptr);
++		UnPremultiplyLine(toBytes, fromBytes, width * height);
+ 	}
+ }
+
+ void PremultiplyInplace(QImage &image) {
+-	const auto layout = &qPixelLayouts[QImage::Format_ARGB32];
+-	const auto convert = layout->convertToARGB32PM;
+ 	const auto perLine = image.bytesPerLine();
+ 	const auto width = image.width();
++	const auto height = image.height();
++	auto bytes = image.bits();
+ 	if (perLine != width * 4) {
+-		auto bytes = image.bits();
+-		for (auto i = 0; i != image.height(); ++i) {
+-			convert(
+-				reinterpret_cast<uint*>(bytes),
+-				reinterpret_cast<const uint*>(bytes),
+-				width,
+-				layout,
+-				nullptr);
++		for (auto i = 0; i != height; ++i) {
++			PremultiplyLine(bytes, bytes, width);
+ 			bytes += perLine;
+ 		}
+ 	} else {
+-		convert(
+-			reinterpret_cast<uint*>(image.bits()),
+-			reinterpret_cast<const uint*>(image.bits()),
+-			image.width() * image.height(),
+-			layout,
+-			nullptr);
++		PremultiplyLine(bytes, bytes, width * height);
+ 	}
+ }

--- a/net-im/telegram-desktop/telegram-desktop-1.7.14.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-1.7.14.ebuild
@@ -39,6 +39,7 @@ COMMON_DEPEND="
 	dev-cpp/range-v3:=
 	dev-libs/rapidjson:=
 	dev-libs/xxhash:=
+	app-arch/lz4:=
 	media-video/ffmpeg:=
 	media-libs/opus:=
 	x11-libs/libdrm:=

--- a/net-im/telegram-desktop/telegram-desktop-9999.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-9999.ebuild
@@ -39,6 +39,7 @@ COMMON_DEPEND="
 	dev-cpp/range-v3:=
 	dev-libs/rapidjson:=
 	dev-libs/xxhash:=
+	app-arch/lz4:=
 	media-video/ffmpeg:=
 	media-libs/opus:=
 	x11-libs/libdrm:=


### PR DESCRIPTION
В общем, я не включаю дефайн TDESKTOP_OFFICIAL_TARGET (https://github.com/telegramdesktop/tdesktop/commit/0710dde4d5526454318b2748331e887c01ecfdce), поэтому всё работает, анимируется, крутится и вертится без приватных заголовков Qt.
Как только выйдет 1.7.15, удаляем патч 0002. Это и есть коммит выше только с удаленным измением файла gyp, которое в нем же содержится. Как-то так.