### PR TITLE
net-im/telegram-desktop: dev-qt/*[xcb -> X]

### DIFF
--- a/net-im/telegram-desktop/ChangeLog
+++ b/net-im/telegram-desktop/ChangeLog
@@ -1,0 +1,6 @@
+*telegram-desktop-1.9.3-r1 (23 Jan 2020)
+
+  23 Jan 2020;  <stefan@gentoo.org> +telegram-desktop-1.9.3-r1.ebuild,
+  -telegram-desktop-1.9.3.ebuild:
+  net-im/telegram-desktop: dev-qt/*[xcb -> X]  Closes:
+  https://github.com/msva/mva-overlay/issues/136

--- a/net-im/telegram-desktop/telegram-desktop-1.9.3-r1.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-1.9.3-r1.ebuild
@@ -64,9 +64,15 @@ COMMON_DEPEND="
 	dev-libs/xxhash:=
 	dev-qt/qtcore:5=
 	dev-qt/qtdbus:5=
-	dev-qt/qtgui:5=[ibus=,xcb,jpeg,png]
+	|| (
+		dev-qt/qtgui:5[ibus=,jpeg,png,X(-)]
+		dev-qt/qtgui:5[ibus=,jpeg,png,xcb(-)]
+	)
 	dev-qt/qtnetwork:5=[connman=,networkmanager=]
-	dev-qt/qtwidgets:5=[xcb,png]
+	|| (
+		dev-qt/qtwidgets:5[png,X(-)]
+		dev-qt/qtwidgets:5[png,xcb(-)]
+	)
 	dev-qt/qtimageformats:5=
 	gnome? (
 		x11-themes/QGnomePlatform


### PR DESCRIPTION
Closes: https://github.com/msva/mva-overlay/issues/136
Package-Manager: Portage-2.3.84, Repoman-2.3.20
Signed-off-by: Stefan Strogin <steils@gentoo.org>