### PR TITLE
Fixes 4.8.4 and 9999

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-4.8.4.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-4.8.4.ebuild
@@ -67,6 +67,7 @@ COMMON_DEPEND="
 	dev-libs/xxhash:=
 	dev-libs/libdispatch
 	dev-libs/libsigc++:2
+	dev-libs/libfmt:=
 	media-fonts/open-sans:*
 	media-libs/fontconfig:=
 	media-libs/rnnoise:=

--- a/net-im/telegram-desktop/telegram-desktop-4.8.4.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-4.8.4.ebuild
@@ -116,7 +116,6 @@ COMMON_DEPEND="
 	dev-cpp/abseil-cpp:=
 	media-libs/libjpeg-turbo:=
 	media-libs/libyuv:=
-	dev-libs/openssl:=
 	>=media-libs/tg_owt-0_pre20230401[pipewire(-)=,screencast=,X=]
 	wayland? (
 		kde-frameworks/kwayland:=

--- a/net-im/telegram-desktop/telegram-desktop-9999.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-9999.ebuild
@@ -67,6 +67,7 @@ COMMON_DEPEND="
 	dev-libs/xxhash:=
 	dev-libs/libdispatch
 	dev-libs/libsigc++:2
+	dev-libs/libfmt:=
 	media-fonts/open-sans:*
 	media-libs/fontconfig:=
 	media-libs/rnnoise:=

--- a/net-im/telegram-desktop/telegram-desktop-9999.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-9999.ebuild
@@ -116,7 +116,6 @@ COMMON_DEPEND="
 	dev-cpp/abseil-cpp:=
 	media-libs/libjpeg-turbo:=
 	media-libs/libyuv:=
-	dev-libs/openssl:=
 	>=media-libs/tg_owt-0_pre20230401[pipewire(-)=,screencast=,X=]
 	wayland? (
 		kde-frameworks/kwayland:=


### PR DESCRIPTION
There was missed dev-libs/libfmt dependency that causes build failure. Also duplicate dev-libs/openssl dependency was removed.