### PR TITLE
net-p2p/etherwall: add missing dependency

### DIFF
--- a/net-p2p/etherwall/etherwall-3.0.5.ebuild
+++ b/net-p2p/etherwall/etherwall-3.0.5.ebuild
@@ -28,6 +28,8 @@ BDEPEND="
 	${BDEPEND}
 	dev-libs/protobuf
 "
+DEPEND="dev-qt/qtwebsockets:5"
+RDEPEND="${DEPEND}"
 
 src_prepare() {
 	default

--- a/net-p2p/etherwall/etherwall-9999.ebuild
+++ b/net-p2p/etherwall/etherwall-9999.ebuild
@@ -28,6 +28,8 @@ BDEPEND="
 	${BDEPEND}
 	dev-libs/protobuf
 "
+DEPEND="dev-qt/qtwebsockets:5"
+RDEPEND="${DEPEND}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
qmake complains about: “Project ERROR: Unknown module(s) in QT: websockets”

[etherwall-3.0.5:20240628-055900.log](https://github.com/user-attachments/files/16025076/etherwall-3.0.5.20240628-055900.log)
